### PR TITLE
Added new tests in order to cover connection multiplexer with validation exceptions.

### DIFF
--- a/src/Exceptions/PenzleException.cs
+++ b/src/Exceptions/PenzleException.cs
@@ -23,13 +23,14 @@ public class PenzleException : Exception
     {
     }
 
-    protected PenzleException(SerializationInfo serializationInfo, StreamingContext streamingContext) : base(info: serializationInfo, context: streamingContext)
+    internal PenzleException(SerializationInfo serializationInfo, StreamingContext streamingContext) : base(info: serializationInfo, context: streamingContext)
     {
         Guard.ArgumentNotNull(value: serializationInfo, name: nameof(serializationInfo));
         StatusCode = (HttpStatusCode)serializationInfo.GetValue(name: nameof(StatusCode), type: typeof(HttpStatusCode));
         ApiError = (ApiError)serializationInfo.GetValue(name: nameof(ApiError), type: typeof(ApiError));
         HttpResponse = (IResponse)serializationInfo.GetValue(name: nameof(HttpResponse), type: typeof(IResponse));
     }
+
 
     internal PenzleException(string message) : base(message: message)
     {
@@ -66,8 +67,7 @@ public class PenzleException : Exception
         base.GetObjectData(info: info, context: context);
         info.AddValue(name: nameof(ApiError), value: ApiError);
         info.AddValue(name: nameof(HttpResponse), value: HttpResponse);
-        info.AddValue(name: nameof(ApiError), value: ApiError);
-        info.AddValue(name: nameof(HttpResponse), value: HttpResponse);
+        info.AddValue(name: nameof(StatusCode), value: (int)StatusCode);
     }
 
     private static ApiError GetApiErrorFromExceptionMessage(IResponse response)
@@ -76,7 +76,7 @@ public class PenzleException : Exception
         return GetApiErrorFromExceptionMessage(responseContent: responseBody);
     }
 
-    private static ApiError GetApiErrorFromExceptionMessage(string responseContent)
+    internal static ApiError GetApiErrorFromExceptionMessage(string responseContent)
     {
         var error = new ApiError(title: responseContent);
         try

--- a/src/Http/Credentials.cs
+++ b/src/Http/Credentials.cs
@@ -5,6 +5,8 @@
 /// </summary>
 public abstract class Credentials
 {
+    protected Credentials() { }
+
     protected Credentials(AuthenticationType authenticationType)
     {
         if (!Enum.IsDefined(enumType: typeof(AuthenticationType), value: authenticationType))

--- a/src/Http/Credentials.cs
+++ b/src/Http/Credentials.cs
@@ -18,5 +18,5 @@ public abstract class Credentials
     /// <summary>
     ///     The various authentication methods that are provided by the Penzle API.
     /// </summary>
-    public AuthenticationType AuthenticationType { get; }
+    public virtual AuthenticationType AuthenticationType { get; set; }
 }

--- a/tests/Penzle.Core.Tests/Attribute/ConnectionDependenciesDataAttribute.cs
+++ b/tests/Penzle.Core.Tests/Attribute/ConnectionDependenciesDataAttribute.cs
@@ -6,11 +6,14 @@ public sealed class ConnectionDependenciesDataAttribute : DataAttribute
 {
     public override IEnumerable<object[]> GetData(MethodInfo testMethod)
     {
+        var platformInformationMock = new Mock<IPlatformInformation>();
+        platformInformationMock.Setup(information => information.GetPlatformInformation()).Returns("1.0.0");
+
         return new[]
         {
             new object[]
             {
-                new Uri("https://api.penzle.com"), new ApiOptions(project: "main", environment: "staging"), new InMemoryCredentialStore(new BearerCredentials(apiDeliveryKey: "54573d95", apiManagementKey: "5d954573")), new HttpClientAdapter(new HttpClient()), new MicrosoftJsonSerializer(), new SdkPlatformInformation()
+                new Uri("https://api.penzle.com"), new ApiOptions(project: "main", environment: "staging"), new InMemoryCredentialStore(new BearerCredentials(apiDeliveryKey: "54573d95", apiManagementKey: "5d954573")), new HttpClientAdapter(new HttpClient()), new MicrosoftJsonSerializer(), platformInformationMock.Object
             }
         };
     }

--- a/tests/Penzle.Core.Tests/Exceptions/ExceptionShould.cs
+++ b/tests/Penzle.Core.Tests/Exceptions/ExceptionShould.cs
@@ -1,0 +1,107 @@
+﻿// Copyright (c) 2022 Penzle LLC. All Rights Reserved. Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Runtime.Serialization;
+
+namespace Penzle.Core.Tests.Exceptions;
+
+[Trait(name: nameof(TraitDefinitions.Category), value: nameof(TraitDefinitions.Exceptions))]
+public class ExceptionShould
+{
+    [Fact]
+    public void Construct_Penzle_Exception_With_Default_Message()
+    {
+        // Arrange
+        const string Message = "An error occurred with this API request";
+
+        // Act
+        var exception = new PenzleException();
+
+        // Assert
+        exception.Message.Should().Be(Message);
+    }
+
+    [Fact]
+    public void Construct_Penzle_Exception_With_Default_Message_And_Inner_Exception()
+    {
+        // Arrange
+        const string Message = "An error occurred with this API request";
+
+        // Act
+        var exception = new PenzleException(message: Message, innerException: new ArgumentException("This is an inner exception"));
+
+        // Assert
+        exception.Message.Should().Be(Message);
+        exception.InnerException.Should().NotBeNull();
+        exception.InnerException.Should().BeAssignableTo<ArgumentException>();
+    }
+
+    [Fact]
+    public void Construct_Penzle_Exception_With_Default_Custom_Message()
+    {
+        // Arrange
+        const string Message = "An error occurred with this API request";
+
+        // Act
+        var exception = new PenzleException(Message);
+
+        // Assert
+        exception.Message.Should().Be(Message);
+    }
+
+    [Fact]
+    public void Construct_Penzle_Exception_With_Request()
+    {
+        // Arrange
+        var response = new Response(statusCode: HttpStatusCode.BadRequest, body: "This is bad request.", headers: new Dictionary<string, string>(), contentType: "application/json");
+
+        // Act
+        var exception = new PenzleException(response);
+
+        // Assert
+        exception.Message.Should().Be("This is bad request.");
+        exception.HttpResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        exception.StatusCode.Should().BeDefined();
+        exception.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public void Construct_Penzle_Exception_With_SerializationInfo_StreamingContext()
+    {
+        // Arrange
+        var serializationInfo = new SerializationInfo(type: typeof(PenzleException), converter: new FormatterConverter());
+        var context = new StreamingContext(StreamingContextStates.All);
+        var response = new Response(statusCode: HttpStatusCode.BadRequest, body: "This is bad request.", headers: new Dictionary<string, string>(), contentType: "application/json");
+
+        // Act
+        var exception = new PenzleException(response);
+        exception.GetObjectData(info: serializationInfo, context: context);
+
+        // Assert
+        serializationInfo.GetInt32("StatusCode").Should().Be((int)HttpStatusCode.BadRequest);
+        serializationInfo.GetValue(name: "HttpResponse", type: typeof(Response)).Should().Be(response);
+        serializationInfo.GetValue(name: "ApiError", type: typeof(ApiError)).Should().NotBeNull().And.Subject.As<ApiError>().Title.Should().Be("This is bad request.");
+    }
+
+    [Fact]
+    public void Construct_Penzle_Exception_With_Exception_Message()
+    {
+        // Arrange
+        var exception = PenzleException.GetApiErrorFromExceptionMessage("This is bad request.");
+
+        // Assert
+        exception.Title.Should().Be("This is bad request.");
+    }
+    
+    [Fact]
+    public void Construct_Penzle_Exception_With_Request_And_Format_Error_Message_Using_ToString()
+    {
+        // Arrange
+        var response = new Response(statusCode: HttpStatusCode.BadRequest, body: "This is bad request.", headers: new Dictionary<string, string>(), contentType: "application/json");
+
+        // Act
+        var exception = new PenzleException(response);
+
+        // Assert
+        exception.ToString().Should().Contain("BadRequest - 400 :: This is bad request.");
+    }
+}

--- a/tests/Penzle.Core.Tests/GlobalUsings.cs
+++ b/tests/Penzle.Core.Tests/GlobalUsings.cs
@@ -13,5 +13,6 @@ global using Penzle.Core.Http.Internal;
 global using Penzle.Core.Models;
 global using Penzle.Core.Tests.Attribute;
 global using Penzle.Core.Tests.Models;
+global using Penzle.Core.Utilities;
 global using Xunit.Sdk;
 global using Xunit;

--- a/tests/Penzle.Core.Tests/Http/RequestShould.cs
+++ b/tests/Penzle.Core.Tests/Http/RequestShould.cs
@@ -95,4 +95,56 @@ public class RequestShould
         request.Should().NotBeNull();
         request.ContentType.Should().Be(expected: ContentType);
     }
+
+    [Fact]
+    public void Ability_To_Set_Request_Headers()
+    {
+        // Arrange
+        var request = new Request
+        {
+            Headers = new Dictionary<string, string>
+            {
+                {
+                    "key", "value"
+                }
+            }
+        };
+
+        // Assert
+        request.Should().NotBeNull();
+        request.Headers.Should().NotBeEmpty();
+    }
+    
+    [Fact]
+    public void Ability_To_Set_Request_Parameters()
+    {
+        // Arrange
+        var request = new Request
+        {
+           Parameters = new Dictionary<string, string>()
+           {
+                {
+                     "key", "value"
+                }
+           }
+        };
+
+        // Assert
+        request.Should().NotBeNull();
+        request.Parameters.Should().NotBeEmpty();
+    }
+    
+    [Fact]
+    public void Ability_To_Set_Request_Timeout()
+    {
+        // Arrange
+        var request = new Request
+        {
+           Timeout = TimeSpan.FromSeconds(60)
+        };
+
+        // Assert
+        request.Should().NotBeNull();
+        request.Timeout.Should().BeGreaterOrEqualTo(TimeSpan.FromMinutes(1));
+    }
 }

--- a/tests/Penzle.Core.Tests/Http/SdkPlatformInformationShould.cs
+++ b/tests/Penzle.Core.Tests/Http/SdkPlatformInformationShould.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) 2022 Penzle LLC. All Rights Reserved. Licensed under the MIT license. See License.txt in the project root for license information.
+
+namespace Penzle.Core.Tests.Http;
+
+[Trait(name: nameof(TraitDefinitions.Category), value: nameof(TraitDefinitions.Platform))]
+public class SdkPlatformInformationShould
+{
+    [Fact]
+    public void Ability_To_Return_Unknown_Platform()
+    {
+        // Arrange
+        var platform = new SdkPlatformInformation();
+
+        // Act
+        var result = platform.PlatformInformation;
+
+        // Assert
+        result.Should().Be("Unknown Platform");
+    }
+
+    [Fact]
+    public void Ability_To_Set_Platform()
+    {
+        // Arrange
+        var platform = new SdkPlatformInformation();
+
+        // Act
+        platform.PlatformInformation = "Test Platform";
+
+        // Assert
+        platform.PlatformInformation.Should().Be("Test Platform");
+    }
+
+    [Fact]
+    public void Ability_To_Return_Platform_Information_If_Empty()
+    {
+        // Arrange
+        var platform = new SdkPlatformInformation();
+
+        // Act
+        platform.PlatformInformation = null;
+
+        // Assert
+        platform.PlatformInformation.Should().BeNull();
+    }
+
+    [Fact]
+    public void Ability_To_Return_Platform_Information_Must_Be_Known()
+    {
+        // Arrange
+        var platform = new SdkPlatformInformation
+        {
+            PlatformInformation = null
+        };
+
+        // Act
+        var platformInformation = platform.GetPlatformInformation();
+
+        // Assert
+        platformInformation.Should().NotBeNullOrWhiteSpace();
+    }
+}

--- a/tests/Penzle.Core.Tests/Models/Article.cs
+++ b/tests/Penzle.Core.Tests/Models/Article.cs
@@ -1,26 +1,25 @@
 ﻿// Copyright (c) 2022 Penzle LLC. All Rights Reserved. Licensed under the MIT license. See License.txt in the project root for license information.
 
-namespace Penzle.Core.Tests.Models
+namespace Penzle.Core.Tests.Models;
+
+public class Article
 {
-    public class Article
-    {
-        [JsonPropertyName("title")] public string? Title { get; init; }
-        [JsonPropertyName("slug")] public string? Slug { get; init; }
-        [JsonPropertyName("banner")] public string? Banner { get; init; }
+    [JsonPropertyName("title")] public string? Title { get; init; }
+    [JsonPropertyName("slug")] public string? Slug { get; init; }
+    [JsonPropertyName("banner")] public string? Banner { get; init; }
 
-        [JsonPropertyName("thumbnail")] public string? Thumbnail { get; init; }
+    [JsonPropertyName("thumbnail")] public string? Thumbnail { get; init; }
 
-        [JsonPropertyName("thumbnailLandscape")]
-        public string? ThumbnailLandscape { get; init; }
+    [JsonPropertyName("thumbnailLandscape")]
+    public string? ThumbnailLandscape { get; init; }
 
-        [JsonPropertyName("description")] public string? Description { get; init; }
+    [JsonPropertyName("description")] public string? Description { get; init; }
 
-        [JsonPropertyName("body")] public string? Body { get; init; }
+    [JsonPropertyName("body")] public string? Body { get; init; }
 
-        [JsonPropertyName("relatedArticle")] public string? RelatedArticle { get; init; }
+    [JsonPropertyName("relatedArticle")] public string? RelatedArticle { get; init; }
 
-        [JsonPropertyName("metaTitle")] public string? MetaTitle { get; init; }
+    [JsonPropertyName("metaTitle")] public string? MetaTitle { get; init; }
 
-        [JsonPropertyName("metaDescription")] public string? MetaDescription { get; init; }
-    }
+    [JsonPropertyName("metaDescription")] public string? MetaDescription { get; init; }
 }

--- a/tests/Penzle.Core.Tests/Models/ArticleWithSystem.cs
+++ b/tests/Penzle.Core.Tests/Models/ArticleWithSystem.cs
@@ -1,0 +1,8 @@
+﻿// Copyright (c) 2022 Penzle LLC. All Rights Reserved. Licensed under the MIT license. See License.txt in the project root for license information.
+
+namespace Penzle.Core.Tests.Models;
+
+public class ArticleWithSystem : Article
+{
+    [JsonPropertyName("system")] public EntrySystem? System { get; init; }
+}

--- a/tests/Penzle.Core.Tests/Penzle.Core.Tests.csproj
+++ b/tests/Penzle.Core.Tests/Penzle.Core.Tests.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="FluentAssertions" Version="6.8.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="Moq" Version="4.18.2" />
+    <PackageReference Include="System.Text.Json" Version="7.0.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -30,6 +31,12 @@
 
   <ItemGroup>
     <None Update="Fixtures\Payloads\GetContentEntry.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Fixtures\Payloads\GetContentEntries.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Fixtures\Payloads\GetContentEntryByAliasUrl.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/tests/Penzle.Core.Tests/Security/BearerCredentialsShould.cs
+++ b/tests/Penzle.Core.Tests/Security/BearerCredentialsShould.cs
@@ -4,20 +4,6 @@
 public sealed class BearerCredentialsShould
 {
     [Fact]
-    public void Construct_BearerCredentials_Without_Proper_AuthenticationType()
-    {
-        // Arrange
-        var mock = new Mock<Credentials>();
-
-        // Act
-        Action handler = () => mock.SetupAllProperties()
-            .SetupProperty(property: credentials => credentials.AuthenticationType, initialValue: Enum.Parse<AuthenticationType>("-1"));
-
-        // Assert
-        handler.Should().Throw<NotSupportedException>();
-    }
-
-    [Fact]
     public void Construct_BearerCredentials_With_Proper_AuthenticationType_Bearer()
     {
         // Arrange

--- a/tests/Penzle.Core.Tests/Security/BearerCredentialsShould.cs
+++ b/tests/Penzle.Core.Tests/Security/BearerCredentialsShould.cs
@@ -4,6 +4,48 @@
 public sealed class BearerCredentialsShould
 {
     [Fact]
+    public void Construct_BearerCredentials_Without_Proper_AuthenticationType()
+    {
+        // Arrange
+        var mock = new Mock<Credentials>();
+
+        // Act
+        Action handler = () => mock.SetupAllProperties()
+            .SetupProperty(property: credentials => credentials.AuthenticationType, initialValue: Enum.Parse<AuthenticationType>("-1"));
+
+        // Assert
+        handler.Should().Throw<NotSupportedException>();
+    }
+
+    [Fact]
+    public void Construct_BearerCredentials_With_Proper_AuthenticationType_Bearer()
+    {
+        // Arrange
+        var mock = new Mock<Credentials>();
+
+        // Act
+        mock.SetupAllProperties()
+            .SetupProperty(property: credentials => credentials.AuthenticationType, initialValue: Enum.Parse<AuthenticationType>("Bearer"));
+
+        // Assert
+        mock.Object.AuthenticationType.Should().Be(AuthenticationType.Bearer);
+    }
+
+    [Fact]
+    public void Construct_BearerCredentials_With_Set_Proper_AuthenticationType_Bearer()
+    {
+        // Arrange
+        var mock = new Mock<Credentials>();
+
+        // Act
+        mock.SetupAllProperties();
+        mock.Object.AuthenticationType = Enum.Parse<AuthenticationType>("Bearer");
+
+        // Assert
+        mock.Object.AuthenticationType.Should().Be(AuthenticationType.Bearer);
+    }
+
+    [Fact]
     public void Set_Delivery_And_Management_Key_Properly()
     {
         // Act

--- a/tests/Penzle.Core.Tests/Serializers/MicrosoftJsonSerializerShould.cs
+++ b/tests/Penzle.Core.Tests/Serializers/MicrosoftJsonSerializerShould.cs
@@ -1,5 +1,6 @@
 ﻿namespace Penzle.Core.Tests.Serializers;
 
+[Trait(name: nameof(TraitDefinitions.Category), value: nameof(TraitDefinitions.Serializers))]
 public class MicrosoftJsonSerializerShould
 {
     [Fact]

--- a/tests/Penzle.Core.Tests/TraitDefinitions.cs
+++ b/tests/Penzle.Core.Tests/TraitDefinitions.cs
@@ -8,4 +8,5 @@ public static class TraitDefinitions
     public static readonly string Connections = "Connections";
     public static readonly string Platform = "Platform";
     public static readonly string Serializers = "Serializers";
+    public static readonly string Exceptions = "Exceptions";
 }

--- a/tests/Penzle.Core.Tests/TraitDefinitions.cs
+++ b/tests/Penzle.Core.Tests/TraitDefinitions.cs
@@ -6,5 +6,6 @@ public static class TraitDefinitions
     public static readonly string Security = "Security";
     public static readonly string Http = "Http";
     public static readonly string Connections = "Connections";
+    public static readonly string Platform = "Platform";
     public static readonly string Serializers = "Serializers";
 }

--- a/tests/Penzle.Core.Tests/TraitDefinitions.cs
+++ b/tests/Penzle.Core.Tests/TraitDefinitions.cs
@@ -9,4 +9,5 @@ public static class TraitDefinitions
     public static readonly string Platform = "Platform";
     public static readonly string Serializers = "Serializers";
     public static readonly string Exceptions = "Exceptions";
+    public static readonly string ApiUrls = "ApiUrls";
 }

--- a/tests/Penzle.Core.Tests/Utilities/ApiUrlsAssetsShould.cs
+++ b/tests/Penzle.Core.Tests/Utilities/ApiUrlsAssetsShould.cs
@@ -1,0 +1,94 @@
+﻿// Copyright (c) 2022 Penzle LLC. All Rights Reserved. Licensed under the MIT license. See License.txt in the project root for license information.
+
+namespace Penzle.Core.Tests.Utilities;
+
+[Trait(name: nameof(TraitDefinitions.Category), value: nameof(TraitDefinitions.ApiUrls))]
+public class ApiUrlsAssetsShould
+{
+    [Fact]
+    public void Construct_Api_Url_For_Get_Asset()
+    {
+        // Arrange
+        var assetId = new Guid("62F55CFF-9CD1-4022-B8CD-751AAA1ACBEB");
+        const string Language = "en-US";
+
+        // Act
+        var uri = ApiUrls.GetAsset(id: assetId, language: Language);
+
+        // Assert
+        uri.Should().NotBeNull();
+        uri.OriginalString.Should().Be($"assets/{assetId}?language={Language}");
+    }
+
+    [Fact]
+    public void Construct_Api_Url_For_Get_Assets()
+    {
+        // Arrange
+        var assetId = new Guid("62F55CFF-9CD1-4022-B8CD-751AAA1ACBEB");
+        const string Language = "en-US";
+
+        // Act
+        var uri = ApiUrls.GetAssets(parentId: assetId, language: Language, keyword: "penzle", tag: "person", mimeType: "image/png", ids: null, page: 1, pageSize: 10, orderBy: "name", direction: "asc");
+
+        // Assert
+        uri.Should().NotBeNull();
+        uri.OriginalString.Should().Be("assets?parentId=62f55cff-9cd1-4022-b8cd-751aaa1acbeb&language=en-US&keyword=penzle&tag=person&mimeType=image/png&page=1&pageSize=10&orderBy=name&direction=asc&ids=");
+    }
+
+    [Fact]
+    public void Construct_Api_Url_For_Add_Asset()
+    {
+        // Arrange
+        var assetId = new Guid("62F55CFF-9CD1-4022-B8CD-751AAA1ACBEB");
+        const string Language = "en-US";
+
+        // Act
+        var uri = ApiUrls.AddAsset(folderId: assetId, language: Language);
+
+        // Assert
+        uri.OriginalString.Should().Be("assets/folder/62f55cff-9cd1-4022-b8cd-751aaa1acbeb/file?language=en-US");
+    }
+
+    [Fact]
+    public void Construct_Api_Url_For_Update_Asset()
+    {
+        // Arrange
+        var assetId = new Guid("62F55CFF-9CD1-4022-B8CD-751AAA1ACBEB");
+        const string Language = "en-US";
+
+        // Act
+        var uri = ApiUrls.UpdateAsset(id: assetId, language: Language);
+
+        // Assert
+        uri.OriginalString.Should().Be("assets/file/62f55cff-9cd1-4022-b8cd-751aaa1acbeb?language=en-US");
+    }
+
+    [Fact]
+    public void Construct_Api_Url_For_Delete_Assets()
+    {
+        // Arrange
+        var assetIdCollection = new[]
+        {
+            new Guid("62F55CFF-9CD1-4022-B8CD-751AAA1ACBEB"), new Guid("62F55CFF-9CD1-4022-B8CD-751AAA1ACBEC")
+        };
+
+        // Act
+        var uri = ApiUrls.DeleteAssets(assetIdCollection);
+
+        // Assert
+        uri.OriginalString.Should().Be("assets?ids=62f55cff-9cd1-4022-b8cd-751aaa1acbeb&ids=62f55cff-9cd1-4022-b8cd-751aaa1acbec");
+    }
+
+    [Fact]
+    public void Construct_Api_Url_For_Delete_Assets_Must_Be_Protected()
+    {
+        // Arrange
+        var assetIdCollection = Array.Empty<Guid>();
+
+        // Act
+        var handler = () => ApiUrls.DeleteAssets(assetIdCollection);
+
+        // Assert
+        handler.Should().Throw<ArgumentNullException>();
+    }
+}

--- a/tests/Penzle.Core.Tests/Utilities/ApiUrlsEntriesShould.cs
+++ b/tests/Penzle.Core.Tests/Utilities/ApiUrlsEntriesShould.cs
@@ -1,0 +1,91 @@
+﻿// Copyright (c) 2022 Penzle LLC. All Rights Reserved. Licensed under the MIT license. See License.txt in the project root for license information.
+
+namespace Penzle.Core.Tests.Utilities;
+
+[Trait(name: nameof(TraitDefinitions.Category), value: nameof(TraitDefinitions.ApiUrls))]
+public class ApiUrlsEntriesShould
+{
+    [Fact]
+    public void Construct_Api_Url_For_Get_Entry()
+    {
+        // Arrange
+        var entryId = new Guid("62F55CFF-9CD1-4022-B8CD-751AAA1ACBEB");
+        const string Language = "en-US";
+
+        // Act
+        var uri = ApiUrls.GetEntry(entryId: entryId, language: Language);
+
+        // Assert
+        uri.Should().NotBeNull();
+        uri.OriginalString.Should().Be("entries/62f55cff-9cd1-4022-b8cd-751aaa1acbeb?language=en-US");
+    }
+
+    [Fact]
+    public void Construct_Api_Url_For_Get_Entries()
+    {
+        // Arrange
+        var entryId = new Guid("62F55CFF-9CD1-4022-B8CD-751AAA1ACBEB");
+        const string Language = "en-US";
+
+        // Act
+        var uri = ApiUrls.GetEntries(template: "article", parentId: entryId, language: Language, ids: null, page: 1, pageSize: 10);
+
+        // Assert
+        uri.Should().NotBeNull();
+        uri.OriginalString.Should().Be("entries/article?parentId=62f55cff-9cd1-4022-b8cd-751aaa1acbeb&language=en-US&page=1&pageSize=10&ids=");
+    }
+
+    [Fact]
+    public void Construct_Api_Url_For_Get_Entry_By_Alias_Url()
+    {
+        // Arrange
+        const string Url = "articles/2021/01/01/first-article";
+        const string Language = "en-US";
+
+        // Act
+        var uri = ApiUrls.GetEntryByAliasUrl(uri: Url, language: Language);
+
+        // Assert
+        uri.Should().NotBeNull();
+        uri.OriginalString.Should().Be("entries/url?language=en-US&aliasUrl=articles/2021/01/01/first-article");
+    }
+
+    [Fact]
+    public void Construct_Api_Url_For_Create_Entry()
+    {
+        // Act
+        var uri = ApiUrls.CreateEntry();
+
+        // Assert
+        uri.Should().NotBeNull();
+        uri.OriginalString.Should().Be("entries");
+    }
+
+    [Fact]
+    public void Construct_Api_Url_For_Update_Entry()
+    {
+        // Arrange
+        var entryId = new Guid("03FA65F2-690E-4DBB-A486-57A28ED980A5");
+
+        // Act
+        var uri = ApiUrls.UpdateEntry(entryId);
+
+        // Assert
+        uri.Should().NotBeNull();
+        uri.OriginalString.Should().Be("entries/03fa65f2-690e-4dbb-a486-57a28ed980a5");
+    }
+
+    [Fact]
+    public void Construct_Api_Url_For_Delete_Entry()
+    {
+        // Arrange
+        var entryId = new Guid("03FA65F2-690E-4DBB-A486-57A28ED980A5");
+
+        // Act
+        var uri = ApiUrls.DeleteEntry(entryId);
+
+        // Assert
+        uri.Should().NotBeNull();
+        uri.OriginalString.Should().Be("entries/03fa65f2-690e-4dbb-a486-57a28ed980a5");
+    }
+}

--- a/tests/Penzle.Core.Tests/Utilities/ApiUrlsFormsShould.cs
+++ b/tests/Penzle.Core.Tests/Utilities/ApiUrlsFormsShould.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) 2022 Penzle LLC. All Rights Reserved. Licensed under the MIT license. See License.txt in the project root for license information.
+
+namespace Penzle.Core.Tests.Utilities;
+
+[Trait(name: nameof(TraitDefinitions.Category), value: nameof(TraitDefinitions.ApiUrls))]
+public class ApiUrlsFormsShould
+{
+    [Fact]
+    public void Construct_Api_Url_For_Get_Form()
+    {
+        // Arrange
+        var formId = new Guid("62F55CFF-9CD1-4022-B8CD-751AAA1ACBEB");
+        const string Language = "en-US";
+
+        // Act
+        var uri = ApiUrls.GetForm(formId: formId, language: Language);
+
+        // Assert
+        uri.Should().NotBeNull();
+        uri.OriginalString.Should().Be("forms/62f55cff-9cd1-4022-b8cd-751aaa1acbeb?language=en-US");
+    }
+
+    [Fact]
+    public void Construct_Api_Url_For_Create_Form()
+    {
+        // Act
+        var uri = ApiUrls.CreateForm();
+
+        // Assert
+        uri.Should().NotBeNull();
+        uri.OriginalString.Should().Be("forms");
+    }
+
+    [Fact]
+    public void Construct_Api_Url_For_Update_Form()
+    {
+        // Arrange
+        var formId = new Guid("62F55CFF-9CD1-4022-B8CD-751AAA1ACBEB");
+
+        // Act
+        var uri = ApiUrls.UpdateForm(formId: formId);
+
+        // Assert
+        uri.Should().NotBeNull();
+        uri.OriginalString.Should().Be("forms/62f55cff-9cd1-4022-b8cd-751aaa1acbeb");
+    }
+
+    [Fact]
+    public void Construct_Api_Url_For_Delete_Form()
+    {
+        // Arrange
+        var formId = new Guid("62F55CFF-9CD1-4022-B8CD-751AAA1ACBEB");
+
+        // Act
+        var uri = ApiUrls.DeleteForm(formId: formId);
+
+        // Assert
+        uri.Should().NotBeNull();
+        uri.OriginalString.Should().Be("forms/62f55cff-9cd1-4022-b8cd-751aaa1acbeb");
+    }
+}

--- a/tests/Penzle.Core.Tests/Utilities/ApiUrlsTemplatesShould.cs
+++ b/tests/Penzle.Core.Tests/Utilities/ApiUrlsTemplatesShould.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) 2022 Penzle LLC. All Rights Reserved. Licensed under the MIT license. See License.txt in the project root for license information.
+
+namespace Penzle.Core.Tests.Utilities;
+
+[Trait(name: nameof(TraitDefinitions.Category), value: nameof(TraitDefinitions.ApiUrls))]
+public class ApiUrlsTemplatesShould
+{
+    [Fact]
+    public void Construct_Api_Url_For_Get_Template()
+    {
+        // Arrange
+        var templateId = new Guid("EA893052-CE53-4549-A4A6-075BB210518B");
+
+        // Act
+        var uri = ApiUrls.GetTemplate(templateId);
+
+        // Assert
+        uri.Should().NotBeNull();
+        uri.OriginalString.Should().Be("templates/ea893052-ce53-4549-a4a6-075bb210518b/schema");
+    }
+
+    [Fact]
+    public void Construct_Api_Url_For_Get_Template_By_CodeName()
+    {
+        // Arrange
+        const string CodeName = "article";
+
+        // Act
+        var uri = ApiUrls.GetTemplateByCodeName(CodeName);
+
+        // Assert
+        uri.Should().NotBeNull();
+        uri.OriginalString.Should().Be("templates/article/schema");
+    }
+}

--- a/tests/Penzle.Core.Tests/Utilities/GuardShould.cs
+++ b/tests/Penzle.Core.Tests/Utilities/GuardShould.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) 2022 Penzle LLC. All Rights Reserved. Licensed under the MIT license. See License.txt in the project root for license information.
+
+namespace Penzle.Core.Tests.Utilities;
+
+public class GuardShould
+{
+    [Fact]
+    public void Ensure_That_Values_Are_Protected_From_Empty_Strings()
+    {
+        // Arrange
+        const string Value = "This is a test";
+
+        // Act
+        var handler = () => Guard.ArgumentNotNullOrEmptyString(value: Value, name: nameof(Value));
+
+        // Assert
+        handler.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Ensure_That_Values_Are_Protected_From_Empty_Strings_If_Null()
+    {
+        // Arrange
+        string value = null;
+
+        // Act
+        var handler = () => Guard.ArgumentNotNullOrEmptyString(value: value, name: nameof(value));
+
+        // Assert
+        handler.Should().Throw<ArgumentException>().And.Message.Should().Be("Value cannot be null. (Parameter 'value')");
+    }
+
+    [Fact]
+    public void Ensure_That_Values_Are_Protected_From_Empty_Strings_If_Empty_Space()
+    {
+        // Arrange
+        const string Value = " ";
+
+        // Act
+        var handler = () => Guard.ArgumentNotNullOrEmptyString(value: Value, name: nameof(Value));
+
+        // Assert
+        handler.Should().Throw<ArgumentException>().And.Message.Should().Be("String cannot be empty (Parameter 'Value')");
+    }
+}


### PR DESCRIPTION
- [Added new test in order to cover connection multiplexer.](https://github.com/Penzle/Penzle.Net/commit/e2713ca10f79f201ed50b75f66239d17d3097529)
- [Added additional test for RequestShould.cs](https://github.com/Penzle/Penzle.Net/commit/9a95532a246fcc07df180fc7aa3635cc043a9ad5)
- [Added more test around security](https://github.com/Penzle/Penzle.Net/commit/3af23190e15802df9ff3c03ddec84952b9a9e72a)
- [Added ExceptionShould.cs in order to validate exception behavior.](https://github.com/Penzle/Penzle.Net/commit/a405efb7dded323595d689d5a479c2ebba2109a2)
- [Added unit test in order to protect ApiUrls and Ensure.](https://github.com/Penzle/Penzle.Net/commit/20396864348eac4b15e2b3cf604006136c442eed)